### PR TITLE
SIMD for Primitve Vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,94 @@ time                 121.1 ns   (121.0 ns .. 121.2 ns)
 mean                 121.1 ns   (121.1 ns .. 121.2 ns)
 std dev              237.2 ps   (137.7 ps .. 369.8 ps)
 ```
+
+
+## Full Benchmarks
+
+`Storable` SIMD uses FFI and C, while `Primitive` uses `GHC.Prim` SIMD and LLVM
+backend.
+
+Benchmarks done using 128 SIMD vectors on i7-3740QM
+
+
+```
+Benchmark vector-simd-bench: RUNNING...
+benchmarking Int32/Sum Storable/vector implementation
+time                 578.2 ns   (577.0 ns .. 579.7 ns)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 580.4 ns   (579.1 ns .. 581.5 ns)
+std dev              3.974 ns   (3.396 ns .. 4.918 ns)
+
+benchmarking Int32/Sum Storable/simd implementation
+time                 168.4 ns   (168.0 ns .. 168.7 ns)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 167.9 ns   (167.6 ns .. 168.3 ns)
+std dev              1.216 ns   (1.048 ns .. 1.472 ns)
+
+benchmarking Int32/Sum Primitive/vector implementation
+time                 585.5 ns   (582.8 ns .. 587.8 ns)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 583.2 ns   (582.0 ns .. 584.4 ns)
+std dev              4.107 ns   (3.303 ns .. 5.480 ns)
+
+benchmarking Int32/Sum Primitive/simd implementation
+time                 163.0 ns   (162.6 ns .. 163.4 ns)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 163.1 ns   (162.7 ns .. 163.4 ns)
+std dev              1.074 ns   (894.2 ps .. 1.392 ns)
+
+benchmarking Int64/Sum Storable/vector implementation
+time                 443.5 ns   (439.3 ns .. 448.7 ns)
+                     0.999 R²   (0.997 R² .. 1.000 R²)
+mean                 431.7 ns   (426.5 ns .. 437.6 ns)
+std dev              17.49 ns   (14.40 ns .. 25.96 ns)
+variance introduced by outliers: 58% (severely inflated)
+
+benchmarking Int64/Sum Storable/simd implementation
+time                 191.0 ns   (186.5 ns .. 195.2 ns)
+                     0.998 R²   (0.997 R² .. 1.000 R²)
+mean                 187.8 ns   (186.8 ns .. 189.9 ns)
+std dev              4.587 ns   (2.593 ns .. 7.114 ns)
+variance introduced by outliers: 35% (moderately inflated)
+
+benchmarking Int64/Sum Primitive/vector implementation
+time                 429.8 ns   (424.4 ns .. 437.4 ns)
+                     0.998 R²   (0.998 R² .. 0.999 R²)
+mean                 443.3 ns   (438.9 ns .. 446.9 ns)
+std dev              13.69 ns   (10.72 ns .. 16.27 ns)
+variance introduced by outliers: 45% (moderately inflated)
+
+benchmarking Int64/Sum Primitive/simd implementation
+time                 330.3 ns   (327.2 ns .. 331.9 ns)
+                     0.999 R²   (0.999 R² .. 1.000 R²)
+mean                 320.5 ns   (317.3 ns .. 324.0 ns)
+std dev              11.16 ns   (10.43 ns .. 11.79 ns)
+variance introduced by outliers: 51% (severely inflated)
+
+benchmarking Double/Sum Storable/vector implementation
+time                 854.6 ns   (852.2 ns .. 856.9 ns)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 863.0 ns   (857.2 ns .. 870.7 ns)
+std dev              22.34 ns   (15.82 ns .. 27.23 ns)
+variance introduced by outliers: 35% (moderately inflated)
+
+benchmarking Double/Sum Storable/simd implementation
+time                 458.4 ns   (449.5 ns .. 473.4 ns)
+                     0.995 R²   (0.987 R² .. 0.999 R²)
+mean                 468.6 ns   (463.4 ns .. 485.4 ns)
+std dev              28.01 ns   (10.22 ns .. 54.97 ns)
+variance introduced by outliers: 75% (severely inflated)
+
+benchmarking Double/Sum Primitive/vector implementation
+time                 851.7 ns   (849.1 ns .. 855.3 ns)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 856.7 ns   (854.3 ns .. 858.3 ns)
+std dev              6.546 ns   (5.526 ns .. 8.181 ns)
+
+benchmarking Double/Sum Primitive/simd implementation
+time                 428.8 ns   (427.9 ns .. 429.8 ns)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 427.9 ns   (426.9 ns .. 429.1 ns)
+std dev              3.714 ns   (2.807 ns .. 5.095 ns)
+
+```

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,26 +1,38 @@
+{-# LANGUAGE TypeApplications #-}
 module Main where
 
-import Control.DeepSeq
 import Criterion
 import Criterion.Main
 import Data.Int
 import qualified Data.Vector.SIMD as V
-import qualified Data.Vector.Storable as V
+import qualified Data.Vector.Primitive as VP
+import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Generic as VG
 
 main :: IO ()
-main =
-    defaultMain
-    [ bgroup "main"
-        [ mkGroup "sum" V.sum V.ssum
+main = do
+  let n = 1000
+  defaultMain
+    [ bgroup
+        "Int32"
+        [ mkGroup "Sum Storable" (VG.enumFromN @VS.Vector @Int32 0 n)
+        , mkGroup "Sum Primitive" (VG.enumFromN @VP.Vector @Int32 0 n)
+        ]
+    , bgroup
+        "Int64"
+        [ mkGroup "Sum Storable" (VG.enumFromN @VS.Vector @Int64 0 n)
+        , mkGroup "Sum Primitive" (VG.enumFromN @VP.Vector @Int64 0 n)
+        ]
+    , bgroup
+        "Double"
+        [ mkGroup "Sum Storable" (VG.enumFromN @VS.Vector @Double 0 n)
+        , mkGroup "Sum Primitive" (VG.enumFromN @VP.Vector @Double 0 n)
         ]
     ]
 
-vLarge :: V.Vector Int32
-vLarge = V.replicate 1000 1
-
-mkGroup :: NFData r => String -> (V.Vector Int32 -> r) -> (V.Vector Int32 -> r) -> Benchmark
-mkGroup name vec smid =
+mkGroup :: (V.SIMDVecVal v a, VG.Vector v a, Num a) => String -> v a -> Benchmark
+mkGroup name v =
     bgroup name
-    [ bench "vector implementation" $ nf vec vLarge
-    , bench "simd implementation" $ nf smid vLarge
+    [ bench "vector implementation" $ whnf VG.sum v
+    , bench "simd implementation" $ whnf V.ssum v
     ]

--- a/src/Data/Vector/SIMD.hs
+++ b/src/Data/Vector/SIMD.hs
@@ -1,33 +1,116 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE MagicHash                #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE UnboxedTuples            #-}
 module Data.Vector.SIMD
     ( SIMDVecVal(..)
-    , V.Vector
     )
 where
 
-import Data.Int
-import Foreign
-import System.IO.Unsafe
-import qualified Data.Vector.Storable as V
+import           Data.Int
+import           Data.Primitive.ByteArray
+import qualified Data.Vector.Generic      as VG
+import qualified Data.Vector.Primitive    as VP
+import qualified Data.Vector.Storable     as VS
+import           Foreign
+import           GHC.Float
+import           GHC.Int
+import           GHC.Prim
+import           System.IO.Unsafe
 
-class SIMDVecVal a where
-    ssum :: V.Vector a -> a
+class VG.Vector v a => SIMDVecVal v a where
+    ssum :: v a -> a
 
-instance SIMDVecVal Int32 where
+instance SIMDVecVal VS.Vector Int32 where
     ssum v =
         unsafePerformIO $
-        V.unsafeWith v $ \ptr -> sum_vec_i32 ptr (V.length v)
+        VS.unsafeWith v $ \ptr -> sum_vec_i32 ptr (VS.length v)
 
-instance SIMDVecVal Int64 where
+instance SIMDVecVal VS.Vector Int64 where
     ssum v =
         unsafePerformIO $
-        V.unsafeWith v $ \ptr -> sum_vec_i64 ptr (V.length v)
+        VS.unsafeWith v $ \ptr -> sum_vec_i64 ptr (VS.length v)
 
-instance SIMDVecVal Double where
+instance SIMDVecVal VS.Vector Double where
     ssum v =
         unsafePerformIO $
-        V.unsafeWith v $ \ptr -> sum_vec_dbl ptr (V.length v)
+        VS.unsafeWith v $ \ptr -> sum_vec_dbl ptr (VS.length v)
 
 foreign import ccall unsafe "sum_vec_i32" sum_vec_i32 :: Ptr Int32 -> Int -> IO Int32
 foreign import ccall unsafe "sum_vec_i64" sum_vec_i64 :: Ptr Int64 -> Int -> IO Int64
 foreign import ccall unsafe "sum_vec_dbl" sum_vec_dbl :: Ptr Double -> Int -> IO Double
+
+
+instance SIMDVecVal VP.Vector Int32 where
+    ssum (VP.Vector _ n ba) = sumByteArrayInt32X4 ba n
+
+
+instance SIMDVecVal VP.Vector Int64 where
+    ssum (VP.Vector _ n ba) = sumByteArrayInt64X2 ba n
+
+
+instance SIMDVecVal VP.Vector Double where
+    ssum (VP.Vector _ n ba) = sumByteArrayDoubleX2 ba n
+
+
+sumByteArrayInt32X4 :: ByteArray -> Int -> Int32
+sumByteArrayInt32X4 (ByteArray ba#) (I# n#) = I32# (addRest# (x0# +# x1# +# x2# +# x3#) q#)
+  where
+    q# = n# -# (n# `remInt#` 4#)
+    (# x0#, x1#, x2#, x3# #) = unpackInt32X4# (goInt32X4# (broadcastInt32X4# 0#) 0#)
+    goInt32X4# acc# i# =
+      case i# <# q# of
+        0# -> acc#
+        _  -> goInt32X4# (plusInt32X4# acc# (indexInt32ArrayAsInt32X4# ba# i#)) (i# +# 4#)
+    addRest# acc# i# =
+      case i# <# n# of
+        0# -> acc#
+        _  -> addRest# (acc# +# indexInt32Array# ba# i#) (i# +# 1#)
+
+
+
+sumByteArrayInt64X2 :: ByteArray -> Int -> Int64
+sumByteArrayInt64X2 (ByteArray ba#) (I# n#) = I64# (addRest# (x0# +# x1#) q#)
+  where
+    q# = n# -# (n# `remInt#` 2#)
+    (# x0#, x1# #) = unpackInt64X2# (goInt64X2# (broadcastInt64X2# 0#) 0#)
+    goInt64X2# acc# i# =
+      case i# <# q# of
+        0# -> acc#
+        _  -> goInt64X2# (plusInt64X2# acc# (indexInt64ArrayAsInt64X2# ba# i#)) (i# +# 2#)
+    addRest# acc# i# =
+      case i# <# n# of
+        0# -> acc#
+        _  -> addRest# (acc# +# indexInt64Array# ba# i#) (i# +# 1#)
+
+
+
+sumByteArrayDoubleX2 :: ByteArray -> Int -> Double
+sumByteArrayDoubleX2 (ByteArray ba#) (I# n#) = D# (addRest# (x0# +## x1#) q#)
+  where
+    q# = n# -# (n# `remInt#` 2#)
+    (# x0#, x1# #) = unpackDoubleX2# (goDoubleX2# (broadcastDoubleX2# 0.0##) 0#)
+    goDoubleX2# acc# i# =
+      case i# <# q# of
+        0# -> acc#
+        _  -> goDoubleX2# (plusDoubleX2# acc# (indexDoubleArrayAsDoubleX2# ba# i#)) (i# +# 2#)
+    addRest# acc# i# =
+      case i# <# n# of
+        0# -> acc#
+        _  -> addRest# (acc# +## indexDoubleArray# ba# i#) (i# +# 1#)
+
+
+-- My CPU only supports 128 bit SIMD
+-- sumByteArrayInt64X4 :: ByteArray -> Int -> Int64
+-- sumByteArrayInt64X4 (ByteArray ba#) (I# n#) = I64# (addRest# (x0# +# x1# +# x2# +# x3#) q#)
+--   where
+--     q# = n# -# (n# `remInt#` 4#)
+--     (# x0#, x1#, x2#, x3# #) = unpackInt64X4# (goInt64X4# (broadcastInt64X4# 0#) 0#)
+--     goInt64X4# acc# i# =
+--       case i# <# q# of
+--         0# -> acc#
+--         _  -> goInt64X4# (plusInt64X4# acc# (indexInt64ArrayAsInt64X4# ba# i#)) (i# +# 4#)
+--     addRest# acc# i# =
+--       case i# <# n# of
+--         0# -> acc#
+--         _  -> addRest# (acc# +# indexInt64Array# ba# i#) (i# +# 1#)

--- a/test/Data/Vector/SIMDSpec.hs
+++ b/test/Data/Vector/SIMDSpec.hs
@@ -6,27 +6,47 @@ module Data.Vector.SIMDSpec (spec) where
 import Data.Int
 import Test.Hspec
 import Test.QuickCheck
+import Data.Proxy
 import qualified Data.Vector.SIMD as V
-import qualified Data.Vector.Storable as V
+import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Generic as VG
+import qualified Data.Vector.Primitive as VP
 
-instance (V.Storable a, Arbitrary a) => Arbitrary (V.Vector a) where
-    arbitrary = V.fromList <$> arbitrary
-    shrink = map V.fromList . shrink . V.toList
+instance (VS.Storable a, Arbitrary a) => Arbitrary (VS.Vector a) where
+    arbitrary = VS.fromList <$> arbitrary
+    shrink = map VS.fromList . shrink . VS.toList
 
-sumSpec :: forall a. (Ord a, Show a, Eq a, Arbitrary a, V.Storable a, Num a, V.SIMDVecVal a) => String -> a -> Spec
-sumSpec name d =
-    describe ("sums for " ++ name) $
-    do it "smid sum should produce correct values" $
-           do V.ssum (V.fromList [1, 10]) `shouldBe` (11 :: a)
-              V.ssum (V.fromList [1, 2, 3, 4]) `shouldBe` (10 :: a)
-              V.ssum (V.fromList [1, 2, 3, 4, 5]) `shouldBe` (15 :: a)
-              V.ssum (V.fromList []) `shouldBe` (0 :: a)
+
+instance (VP.Prim a, Arbitrary a) => Arbitrary (VP.Vector a) where
+    arbitrary = VP.fromList <$> arbitrary
+    shrink = map VP.fromList . shrink . VP.toList
+
+
+sumSpec
+  :: forall v a.
+     (Ord a, Show a, Eq a, Num a, Arbitrary (v a), Show (v a), V.SIMDVecVal v a)
+  => Proxy v -> a -> Spec
+sumSpec _ d =
+    do it "simd sum should produce correct values" $
+           do V.ssum (VG.fromList [1, 10] :: v a) `shouldBe` (11 :: a)
+              V.ssum (VG.fromList [1, 2, 3, 4] :: v a) `shouldBe` (10 :: a)
+              V.ssum (VG.fromList [1, 2, 3, 4, 5] :: v a) `shouldBe` (15 :: a)
+              V.ssum (VG.fromList [] :: v a) `shouldBe` (0 :: a)
        it "simd sum should match sum implementation" $
-           property $ \(vec :: V.Vector a) ->
-                          abs (V.sum vec - V.ssum vec) < d
+           property $ sumProperty @v d
+
+
+sumProperty :: (VG.Vector v a, Arbitrary (v a), V.SIMDVecVal v a, Num a, Ord a) => a -> v a -> Bool
+sumProperty d vec = abs (VG.sum vec - V.ssum vec) <= d
 
 spec :: Spec
-spec =
-    do sumSpec @Int32 "int32" 1
-       sumSpec @Int64 "int64" 1
-       sumSpec @Double "double" 0.001
+spec = do
+  describe "Int32" $ do
+    describe "Storable" $ sumSpec (Proxy :: Proxy VS.Vector) (0 :: Int32)
+    describe "Primitive" $ sumSpec (Proxy :: Proxy VP.Vector) (0 :: Int32)
+  describe "Int64" $ do
+    describe "Storable" $ sumSpec (Proxy :: Proxy VS.Vector) (0 :: Int64)
+    describe "Primitive" $ sumSpec (Proxy :: Proxy VP.Vector) (0 :: Int64)
+  describe "Double" $ do
+    describe "Storable" $ sumSpec (Proxy :: Proxy VS.Vector) (0.00001 :: Double)
+    describe "Primitive" $ sumSpec (Proxy :: Proxy VP.Vector) (0.00001 :: Double)

--- a/vector-simd.cabal
+++ b/vector-simd.cabal
@@ -19,9 +19,11 @@ library
   c-sources:           cbits/sum.c
   cc-options:          -Wall -O2
   build-depends:       base >= 4.7 && < 5
+                     , ghc-prim
+                     , primitive
                      , vector
   default-language:    Haskell2010
-  ghc-options:         -Wall
+  ghc-options:         -Wall -fllvm
 
 test-suite vector-simd-test
   type:                exitcode-stdio-1.0
@@ -33,14 +35,14 @@ test-suite vector-simd-test
                      , hspec
                      , vector
                      , QuickCheck
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -O2
+  ghc-options:         -fllvm -threaded -rtsopts -with-rtsopts=-N -O2
   default-language:    Haskell2010
 
 benchmark vector-simd-bench
   type:                exitcode-stdio-1.0
   main-is:             Bench.hs
   hs-source-dirs:      bench
-  ghc-options:         -Wall -O2
+  ghc-options:         -fllvm -Wall -O2
   build-depends:       base
                      , vector
                      , vector-simd


### PR DESCRIPTION
Decided to mess around a bit with SIMD instructions supported by GHC + LLVM

Turns out there is not much difference from SIMD in C, except for `Int64` for some reason.